### PR TITLE
Remove references to concat::setup

### DIFF
--- a/manifests/menu.pp
+++ b/manifests/menu.pp
@@ -14,8 +14,6 @@ define pxe::menu (
   $root     = 'default',
 ) {
 
-  include concat::setup
-
   $tftp_root = $::pxe::tftp_root
   $fullpath  = "${tftp_root}/pxelinux.cfg"
 

--- a/manifests/menu/installentry.pp
+++ b/manifests/menu/installentry.pp
@@ -24,8 +24,6 @@ define pxe::menu::installentry (
     $menutitle = ''
 ) {
 
-  include concat::setup
-
   if $menutitle == '' {
     $label = $title
   } else {


### PR DESCRIPTION
present, puppet fails to compile a catalog.
This commit removes concat::setup references. Without this change,
puppet fails to compile a catalog because concat::setup does not exist.
